### PR TITLE
Close channels w/ a suspend function.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ allprojects {
 ext {
     // POM file
     GROUP = "com.nytimes.android"
-    VERSION_NAME = "3.1.1-SNAPSHOT"
+    VERSION_NAME = "4.0.0-SNAPSHOT"
     POM_PACKAGING = "pom"
     POM_DESCRIPTION = "Store3 is built with RxJava2"
 

--- a/store/src/main/java/com/nytimes/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/FetcherController.kt
@@ -39,7 +39,7 @@ internal class FetcherController<Key, Input, Output>(
          */
         private val enablePiggyback: Boolean = sourceOfTruth == null
 ) {
-    private val fetchers = RefCountedResource<Key, Multiplexer<StoreResponse<Input>>>(
+    private val fetchers = RefCountedResource(
             create = { key: Key ->
                 Multiplexer(
                         scope = scope,

--- a/store/src/main/java/com/nytimes/android/external/store4/impl/multiplex/Multiplexer.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/multiplex/Multiplexer.kt
@@ -84,7 +84,7 @@ internal class Multiplexer<T>(
             }
     }
 
-    fun close() {
+    suspend fun close() {
         channelManager.close()
     }
 }

--- a/store/src/test/java/com/nytimes/android/external/store3/DontCacheErrorsTest1.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/DontCacheErrorsTest1.kt
@@ -33,8 +33,8 @@ class DontCacheErrorsTest(
         try {
             store.get(barcode)
             fail()
-        } catch (e: RuntimeException) {
-            e.printStackTrace()
+        } catch (_: RuntimeException) {
+            // expected
         }
 
         shouldThrow = false

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/multiplex/StoreRealActorTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/multiplex/StoreRealActorTest.kt
@@ -1,0 +1,61 @@
+package com.nytimes.android.external.store4.impl.multiplex
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.EmptyCoroutineContext
+
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class StoreRealActorTest {
+
+    /**
+     * Intentionally not using test scope here to use real coroutines to ensure we don't get into
+     * race conditions.
+     */
+    @Test
+    fun closeOrder() {
+        val didClose = AtomicBoolean(false)
+        val actor = object : StoreRealActor<String>(CoroutineScope(EmptyCoroutineContext)) {
+            var active = AtomicBoolean(false)
+            override suspend fun handle(msg: String) {
+                try {
+                    active.set(true)
+                    delay(100)
+                } finally {
+                    active.set(false)
+                }
+            }
+
+            override fun onClosed() {
+                assertThat(active.get()).isFalse()
+                didClose.set(true)
+            }
+        }
+        runBlocking {
+            val firstMessageSent = CompletableDeferred<Unit>()
+            val sender = GlobalScope.launch {
+                repeat(500) {
+                    try {
+                        actor.send("a $it")
+                        firstMessageSent.complete(Unit)
+                    } catch (illegal: IllegalStateException) {
+                    }
+                }
+            }
+            firstMessageSent.await()
+            actor.close()
+            sender.join()
+        }
+        assertThat(didClose.get()).isTrue()
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in StoreRealActor where we could call onClose
while actor is processing some messages. Now instead we send a token
to close and inside the message handler we close the channel so that
no new messages can arrive after close meanwhile messages that arrived
before that close is handled properly.

Also set version to 4.0.0 and cleaned up some code.

Fixes #55