### PR TITLE
Rename Multiplex to Multicast

### DIFF
--- a/store/src/main/java/com/nytimes/android/external/store4/impl/FetcherController.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/FetcherController.kt
@@ -2,7 +2,7 @@ package com.nytimes.android.external.store4.impl
 
 import com.nytimes.android.external.store4.ResponseOrigin
 import com.nytimes.android.external.store4.StoreResponse
-import com.nytimes.android.external.store4.impl.multiplex.Multiplexer
+import com.nytimes.android.external.store4.impl.multicast.Multicaster
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -41,7 +41,7 @@ internal class FetcherController<Key, Input, Output>(
 ) {
     private val fetchers = RefCountedResource(
             create = { key: Key ->
-                Multiplexer(
+                Multicaster(
                         scope = scope,
                         bufferSize = 0,
                         source = {
@@ -62,8 +62,8 @@ internal class FetcherController<Key, Input, Output>(
                         }
                 )
             },
-            onRelease = { key: Key, multiplexer: Multiplexer<StoreResponse<Input>> ->
-                multiplexer.close()
+            onRelease = { key: Key, multicaster: Multicaster<StoreResponse<Input>> ->
+                multicaster.close()
             }
     )
 

--- a/store/src/main/java/com/nytimes/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/RealStore.kt
@@ -55,7 +55,7 @@ class RealStore<Key, Input, Output>(
     }
 
     /**
-     * Fetcher controller maintains 1 and only 1 `Multiplexer` for a given key to ensure network
+     * Fetcher controller maintains 1 and only 1 `Multicaster` for a given key to ensure network
      * requests are shared.
      */
     private val fetcherController = FetcherController(

--- a/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/ChannelManager.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/ChannelManager.kt
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.store4.impl.multiplex
+package com.nytimes.android.external.store4.impl.multicast
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope

--- a/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/Multicaster.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/Multicaster.kt
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.store4.impl.multiplex
+package com.nytimes.android.external.store4.impl.multicast
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.transform
  */
 @FlowPreview
 @ExperimentalCoroutinesApi
-internal class Multiplexer<T>(
+internal class Multicaster<T>(
     /**
      * The [CoroutineScope] to use for upstream subscription
      */
@@ -35,7 +35,7 @@ internal class Multiplexer<T>(
     private val source: () -> Flow<T>,
 
     /**
-     * If true, downstream is never closed by the multiplexer unless upstream throws an error.
+     * If true, downstream is never closed by the multicaster unless upstream throws an error.
      * Instead, it is kept open and if a new downstream shows up that causes us to restart the flow,
      * it will receive values as well.
      */

--- a/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/SharedFlowProducer.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/SharedFlowProducer.kt
@@ -1,8 +1,8 @@
-package com.nytimes.android.external.store4.impl.multiplex
+package com.nytimes.android.external.store4.impl.multicast
 
-import com.nytimes.android.external.store4.impl.multiplex.ChannelManager.Message.DispatchError
-import com.nytimes.android.external.store4.impl.multiplex.ChannelManager.Message.DispatchValue
-import com.nytimes.android.external.store4.impl.multiplex.ChannelManager.Message.UpstreamFinished
+import com.nytimes.android.external.store4.impl.multicast.ChannelManager.Message.DispatchError
+import com.nytimes.android.external.store4.impl.multicast.ChannelManager.Message.DispatchValue
+import com.nytimes.android.external.store4.impl.multicast.ChannelManager.Message.UpstreamFinished
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/StoreRealActor.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/impl/multicast/StoreRealActor.kt
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.store4.impl.multiplex
+package com.nytimes.android.external.store4.impl.multicast
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/multicast/ChannelManagerTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/multicast/ChannelManagerTest.kt
@@ -1,8 +1,8 @@
-package com.nytimes.android.external.store4.impl.multiplex
+package com.nytimes.android.external.store4.impl.multicast
 
-import com.nytimes.android.external.store4.impl.multiplex.ChannelManager.Message.AddChannel
-import com.nytimes.android.external.store4.impl.multiplex.ChannelManager.Message.DispatchValue
-import com.nytimes.android.external.store4.impl.multiplex.ChannelManager.Message.RemoveChannel
+import com.nytimes.android.external.store4.impl.multicast.ChannelManager.Message.AddChannel
+import com.nytimes.android.external.store4.impl.multicast.ChannelManager.Message.DispatchValue
+import com.nytimes.android.external.store4.impl.multicast.ChannelManager.Message.RemoveChannel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/multicast/InfiniteMulticastTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/multicast/InfiniteMulticastTest.kt
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.store4.impl.multiplex
+package com.nytimes.android.external.store4.impl.multicast
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -19,19 +19,19 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 /**
- * Multiplexer tests where downstream is not closed even when upstream is closed.
+ * Multicaster tests where downstream is not closed even when upstream is closed.
  * It basically waits until there is another reason to enable upstream and will receive those
  * values as well.
  */
 @FlowPreview
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
-class InfiniteMultiplexTest {
+class InfiniteMulticastTest {
     private val testScope = TestCoroutineScope()
     private val dispatchLog = mutableListOf<String>()
 
-    private fun <T> createMultiplexer(f: () -> Flow<T>): Multiplexer<T> {
-        return Multiplexer(
+    private fun <T> createMulticaster(f: () -> Flow<T>): Multicaster<T> {
+        return Multicaster(
             scope = testScope,
             bufferSize = 0,
             source = f,
@@ -44,7 +44,7 @@ class InfiniteMultiplexTest {
     @Test
     fun piggyback() = testScope.runBlockingTest {
         var createdCount = 0
-        val activeFlow = createMultiplexer {
+        val activeFlow = createMulticaster {
             val id = createdCount++
             flowOf("a$id", "b$id", "c$id").onStart {
                 // make sure both registers on time so that no one drops a value
@@ -77,7 +77,7 @@ class InfiniteMultiplexTest {
     @Test
     fun piggyback_newStreamClosesEarly() = testScope.runBlockingTest {
         var createdCount = 0
-        val activeFlow = createMultiplexer {
+        val activeFlow = createMulticaster {
             val id = createdCount++
             flowOf("a$id", "b$id", "c$id").onStart {
                 // make sure both registers on time so that no one drops a value
@@ -110,7 +110,7 @@ class InfiniteMultiplexTest {
     @Test
     fun piggyback_oldStreamClosesEarly() = testScope.runBlockingTest {
         var createdCount = 0
-        val activeFlow = createMultiplexer {
+        val activeFlow = createMulticaster {
             val id = createdCount++
             flowOf("a$id", "b$id", "c$id").onStart {
                 // make sure both registers on time so that no one drops a value
@@ -143,7 +143,7 @@ class InfiniteMultiplexTest {
     @Test
     fun piggyback_allStreamsCloseSearch() = testScope.runBlockingTest {
         var createdCount = 0
-        val activeFlow = createMultiplexer {
+        val activeFlow = createMulticaster {
             val id = createdCount++
             flowOf("a$id", "b$id", "c$id").transform {
                 // really slow to test early termination

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/multicast/StoreRealActorTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/multicast/StoreRealActorTest.kt
@@ -1,4 +1,4 @@
-package com.nytimes.android.external.store4.impl.multiplex
+package com.nytimes.android.external.store4.impl.multicast
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope


### PR DESCRIPTION
Appearantly, multiplex is N to 1 while this thing is 1 to N. Yigit should consider checking what things mean before using them in code ¯\_(ツ)_/¯