### PR TITLE
store fluent API prototype

### DIFF
--- a/app/src/main/java/com/nytimes/android/sample/Graph.kt
+++ b/app/src/main/java/com/nytimes/android/sample/Graph.kt
@@ -4,9 +4,9 @@ import android.text.Html
 import androidx.room.Room
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.nytimes.android.external.fs3.SourcePersisterFactory
-import com.nytimes.android.external.store4.FlowStoreBuilder
 import com.nytimes.android.external.store4.Persister
 import com.nytimes.android.external.store4.Store
+import com.nytimes.android.external.store4.StoreBuilder
 import com.nytimes.android.external.store4.legacy.BarCode
 import com.nytimes.android.sample.data.model.Children
 import com.nytimes.android.sample.data.model.Post
@@ -20,11 +20,11 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 object Graph {
-    fun provideRoomPipeline(context: SampleApp): Store<String, List<Post>> {
+    fun provideRoomStore(context: SampleApp): Store<String, List<Post>> {
         val db = provideRoom(context)
-        return FlowStoreBuilder
-                .fromNonFlow<String, List<Post>, List<Post>> {
-                    provideRetrofit().fetchSubreddit(it, "10")
+        return StoreBuilder
+                .fromNonFlow { key: String ->
+                    provideRetrofit().fetchSubreddit(key, "10")
                             .await().data.children.map(::toPosts)
                 }
                 .persister(reader = db.postDao()::loadPosts,

--- a/app/src/main/java/com/nytimes/android/sample/RoomActivity.kt
+++ b/app/src/main/java/com/nytimes/android/sample/RoomActivity.kt
@@ -17,11 +17,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 @FlowPreview
@@ -45,7 +41,6 @@ class RoomActivity : AppCompatActivity() {
                 postRecyclerView.adapter = adapter
             }
         }
-
         val storeState = StoreState((application as SampleApp).roomStore)
         lifecycleScope.launchWhenStarted {
             fun refresh() {

--- a/app/src/main/java/com/nytimes/android/sample/SampleApp.kt
+++ b/app/src/main/java/com/nytimes/android/sample/SampleApp.kt
@@ -22,7 +22,7 @@ class SampleApp : Application() {
     override fun onCreate() {
         super.onCreate()
         initPersister()
-        roomStore = Graph.provideRoomPipeline(this)
+        roomStore = Graph.provideRoomStore(this)
     }
 
     private fun initPersister() {

--- a/app/src/main/java/com/nytimes/android/sample/StreamActivity.kt
+++ b/app/src/main/java/com/nytimes/android/sample/StreamActivity.kt
@@ -4,11 +4,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import com.nytimes.android.external.store4.FlowStoreBuilder
-import com.nytimes.android.external.store4.MemoryPolicy
-import com.nytimes.android.external.store4.StoreRequest
-import com.nytimes.android.external.store4.fresh
-import com.nytimes.android.external.store4.get
+import com.nytimes.android.external.store4.*
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
@@ -35,8 +31,8 @@ class StreamActivity : AppCompatActivity(), CoroutineScope {
 
         var counter = 0
 
-        val store = FlowStoreBuilder
-            .fromNonFlow<Int, Int, Int> { key -> (key * 1000 + counter++).also { delay(1_000) } }
+        val store = StoreBuilder
+            .fromNonFlow { key:Int -> (key * 1000 + counter++).also { delay(1_000) } }
             .cachePolicy(
                 MemoryPolicy
                     .builder()

--- a/store/src/main/java/com/nytimes/android/external/store4/FlowStoreBuilder.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/FlowStoreBuilder.kt
@@ -11,27 +11,104 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 object FlowStoreBuilder {
-    fun <Key, Input, Output> fromNonFlow(
-            fetcher: suspend (key: Key) -> Input
-    ) = Builder<Key, Input, Output> { key: Key ->
+    fun <Key, Output> fromNonFlow(
+            fetcher: suspend (key: Key) -> Output
+    ) = Builder { key: Key ->
         flow {
             emit(fetcher(key))
         }
     }
 
-    fun <Key, Input, Output> from(
-            fetcher: (key: Key) -> Flow<Input>
-    ) = Builder<Key, Input, Output>(fetcher)
+    fun <Key, Output> from(
+            fetcher: (key: Key) -> Flow<Output>
+    ) = Builder(fetcher)
 }
 
-class Builder<Key, Input, Output>(
+interface StoreBuilder<Key, Output> {
+    fun build(): Store<Key, Output>
+    fun scope(scope: CoroutineScope) : StoreBuilder<Key, Output>
+    fun cachePolicy(memoryPolicy: MemoryPolicy?): StoreBuilder<Key, Output>
+    fun disableCache(): StoreBuilder<Key, Output>
+}
+
+class Builder<Key, Output>(
+        private val fetcher: (key: Key) -> Flow<Output>
+) : StoreBuilder<Key, Output> {
+    private var scope: CoroutineScope? = null
+    private var cachePolicy: MemoryPolicy? = StoreDefaults.memoryPolicy
+
+    private fun <NewOutput> withSourceOfTruth() = BuilderWithSourceOfTruth<Key, Output, NewOutput>(
+            fetcher
+    ).let { builder ->
+        if (cachePolicy == null) {
+            builder.disableCache()
+        } else {
+            builder.cachePolicy(cachePolicy)
+        }
+    }.let { builder ->
+        scope?.let {
+            builder.scope(it)
+        } ?: builder
+    }
+
+    override fun scope(scope: CoroutineScope): Builder<Key, Output> {
+        this.scope = scope
+        return this
+    }
+
+    override fun cachePolicy(memoryPolicy: MemoryPolicy?): Builder<Key, Output> {
+        cachePolicy = memoryPolicy
+        return this
+    }
+
+    override fun disableCache(): Builder<Key, Output> {
+        cachePolicy = null
+        return this
+    }
+
+    fun <NewOutput> nonFlowingPersister(
+            reader: suspend (Key) -> NewOutput?,
+            writer: suspend (Key, Output) -> Unit,
+            delete: (suspend (Key) -> Unit)? = null
+    ): BuilderWithSourceOfTruth<Key, Output, NewOutput> {
+        return withSourceOfTruth<NewOutput>().nonFlowingPersister(
+                reader = reader,
+                writer = writer,
+                delete = delete
+        )
+    }
+
+    fun <NewOutput> persister(
+            reader: (Key) -> Flow<NewOutput?>,
+            writer: suspend (Key, Output) -> Unit,
+            delete: (suspend (Key) -> Unit)? = null
+    ): BuilderWithSourceOfTruth<Key, Output, NewOutput> {
+        return withSourceOfTruth<NewOutput>().persister(
+                reader = reader,
+                writer = writer,
+                delete = delete
+        )
+    }
+
+    fun <NewOutput> sourceOfTruth(
+            sourceOfTruth: SourceOfTruth<Key, Output, NewOutput>
+    ): BuilderWithSourceOfTruth<Key, Output, NewOutput> {
+        return withSourceOfTruth<NewOutput>().sourceOfTruth(sourceOfTruth)
+    }
+
+    override fun build(): Store<Key, Output> {
+        return withSourceOfTruth<Output>().build()
+    }
+}
+
+class BuilderWithSourceOfTruth<Key, Input, Output>(
         private val fetcher: (key: Key) -> Flow<Input>
-) {
+) : StoreBuilder<Key, Output> {
     private var scope: CoroutineScope? = null
     private var sourceOfTruth: SourceOfTruth<Key, Input, Output>? = null
     private var cachePolicy: MemoryPolicy? = StoreDefaults.memoryPolicy
 
-    fun scope(scope: CoroutineScope): Builder<Key, Input, Output> {
+    override fun scope(scope: CoroutineScope): BuilderWithSourceOfTruth<Key, Input, Output> {
         this.scope = scope
         return this
     }
@@ -40,7 +117,7 @@ class Builder<Key, Input, Output>(
             reader: suspend (Key) -> Output?,
             writer: suspend (Key, Input) -> Unit,
             delete: (suspend (Key) -> Unit)? = null
-    ): Builder<Key, Input, Output> {
+    ): BuilderWithSourceOfTruth<Key, Input, Output> {
         sourceOfTruth = PersistentNonFlowingSourceOfTruth(
                 realReader = reader,
                 realWriter = writer,
@@ -53,7 +130,7 @@ class Builder<Key, Input, Output>(
             reader: (Key) -> Flow<Output?>,
             writer: suspend (Key, Input) -> Unit,
             delete: (suspend (Key) -> Unit)? = null
-    ): Builder<Key, Input, Output> {
+    ): BuilderWithSourceOfTruth<Key, Input, Output> {
         sourceOfTruth = PersistentSourceOfTruth(
                 realReader = reader,
                 realWriter = writer,
@@ -64,23 +141,23 @@ class Builder<Key, Input, Output>(
 
     fun sourceOfTruth(
             sourceOfTruth: SourceOfTruth<Key, Input, Output>
-    ): Builder<Key, Input, Output> {
+    ): BuilderWithSourceOfTruth<Key, Input, Output> {
         this.sourceOfTruth = sourceOfTruth
         return this
     }
 
-    fun cachePolicy(memoryPolicy: MemoryPolicy?): Builder<Key, Input, Output> {
+    override fun cachePolicy(memoryPolicy: MemoryPolicy?): BuilderWithSourceOfTruth<Key, Input, Output> {
         cachePolicy = memoryPolicy
         return this
     }
 
-    fun disableCache(): Builder<Key, Input, Output> {
+    override fun disableCache(): BuilderWithSourceOfTruth<Key, Input, Output> {
         cachePolicy = null
         return this
     }
 
     @ExperimentalCoroutinesApi
-    fun build(): Store<Key, Output> {
+    override fun build(): Store<Key, Output> {
         @Suppress("UNCHECKED_CAST")
         return RealStore(
                 scope = scope ?: GlobalScope,

--- a/store/src/main/java/com/nytimes/android/external/store4/StoreBuilder.kt
+++ b/store/src/main/java/com/nytimes/android/external/store4/StoreBuilder.kt
@@ -10,25 +10,25 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-object FlowStoreBuilder {
-    fun <Key, Output> fromNonFlow(
-            fetcher: suspend (key: Key) -> Output
-    ) = Builder { key: Key ->
-        flow {
-            emit(fetcher(key))
-        }
-    }
-
-    fun <Key, Output> from(
-            fetcher: (key: Key) -> Flow<Output>
-    ) = Builder(fetcher)
-}
-
 interface StoreBuilder<Key, Output> {
     fun build(): Store<Key, Output>
-    fun scope(scope: CoroutineScope) : StoreBuilder<Key, Output>
+    fun scope(scope: CoroutineScope): StoreBuilder<Key, Output>
     fun cachePolicy(memoryPolicy: MemoryPolicy?): StoreBuilder<Key, Output>
     fun disableCache(): StoreBuilder<Key, Output>
+
+    companion object {
+        fun <Key, Output> fromNonFlow(
+                fetcher: suspend (key: Key) -> Output
+        ) = Builder { key: Key ->
+            flow {
+                emit(fetcher(key))
+            }
+        }
+
+        fun <Key, Output> from(
+                fetcher: (key: Key) -> Flow<Output>
+        ) = Builder(fetcher)
+    }
 }
 
 class Builder<Key, Output>(

--- a/store/src/test/java/com/nytimes/android/external/store3/TestStoreBuilder.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/TestStoreBuilder.kt
@@ -1,11 +1,7 @@
 package com.nytimes.android.external.store3
 
 import com.nytimes.android.external.store3.util.KeyParser
-import com.nytimes.android.external.store4.Fetcher
-import com.nytimes.android.external.store4.FlowStoreBuilder
-import com.nytimes.android.external.store4.MemoryPolicy
-import com.nytimes.android.external.store4.Persister
-import com.nytimes.android.external.store4.Store
+import com.nytimes.android.external.store4.*
 import com.nytimes.android.external.store4.impl.SourceOfTruth
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flow
@@ -65,7 +61,7 @@ data class TestStoreBuilder<Key, Output>(
         ): TestStoreBuilder<Key, Output> {
             return TestStoreBuilder(
                 buildStore = {
-                    FlowStoreBuilder
+                    StoreBuilder
                         .from { key: Key ->
                             flow {
                                 val value = fetcher.invoke(key = key)

--- a/store/src/test/java/com/nytimes/android/external/store3/TestStoreBuilder.kt
+++ b/store/src/test/java/com/nytimes/android/external/store3/TestStoreBuilder.kt
@@ -66,7 +66,7 @@ data class TestStoreBuilder<Key, Output>(
             return TestStoreBuilder(
                 buildStore = {
                     FlowStoreBuilder
-                        .from <Key, Output, Output> { key: Key ->
+                        .from { key: Key ->
                             flow {
                                 val value = fetcher.invoke(key = key)
                                 if (fetchParser != null) {
@@ -78,20 +78,19 @@ data class TestStoreBuilder<Key, Output>(
                         }
                         .scope(scope)
                         .let {
-                            if (persister == null) {
-                                it
-                            } else {
-                                it.sourceOfTruth(SourceOfTruth.fromLegacy(persister, postParser))
-                            }
-                        }
-                        .let {
                             if (cached) {
                                 cacheMemoryPolicy?.let { cacheMemoryPolicy->  it.cachePolicy(cacheMemoryPolicy) }?:it
                             } else {
                                 it.disableCache()
                             }
                         }
-                        .build()
+                        .let {
+                            if (persister == null) {
+                                it
+                            } else {
+                                it.sourceOfTruth(SourceOfTruth.fromLegacy(persister, postParser))
+                            }
+                        }.build()
                 }
             )
         }

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/FlowStoreTest.kt
@@ -478,11 +478,11 @@ class FlowStoreTest {
         }
 
         return if (nonFlowingFetcher != null) {
-            FlowStoreBuilder.fromNonFlow(
+            StoreBuilder.fromNonFlow(
                     nonFlowingFetcher
             )
         } else {
-            FlowStoreBuilder.from(
+            StoreBuilder.from(
                     flowingFetcher!!
             )
         }.scope(testScope)

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/FlowStoreTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/FlowStoreTest.kt
@@ -482,9 +482,16 @@ class FlowStoreTest {
                     nonFlowingFetcher
             )
         } else {
-            FlowStoreBuilder.from<Key, Input, Output>(
+            FlowStoreBuilder.from(
                     flowingFetcher!!
             )
+        }.scope(testScope)
+                .let {
+            if (enableCache) {
+                it
+            } else {
+                it.disableCache()
+            }
         }.let {
             when {
                 flowingPersisterReader != null -> it.persister(
@@ -498,15 +505,8 @@ class FlowStoreTest {
                         delete = persisterDelete
                 )
                 else -> it
-            }
-        }.let {
-            if (enableCache) {
-                it
-            } else {
-                it.disableCache()
-            }
-        }.scope(testScope)
-                .build()
+            } as StoreBuilder<Key, Output>
+        }.build()
 
     }
 }

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
@@ -1,7 +1,7 @@
 package com.nytimes.android.external.store4.impl
 
-import com.nytimes.android.external.store4.FlowStoreBuilder
 import com.nytimes.android.external.store4.ResponseOrigin
+import com.nytimes.android.external.store4.StoreBuilder
 import com.nytimes.android.external.store4.StoreRequest
 import com.nytimes.android.external.store4.StoreResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,7 +29,7 @@ class StreamWithoutSourceOfTruthTest(
                 3 to "three-1",
                 3 to "three-2"
         )
-        val pipeline = FlowStoreBuilder.fromNonFlow(fetcher::fetch)
+        val pipeline = StoreBuilder.fromNonFlow(fetcher::fetch)
                 .scope(testScope)
                 .let {
                     if (enableCache) {

--- a/store/src/test/java/com/nytimes/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
+++ b/store/src/test/java/com/nytimes/android/external/store4/impl/StreamWithoutSourceOfTruthTest.kt
@@ -29,7 +29,7 @@ class StreamWithoutSourceOfTruthTest(
                 3 to "three-1",
                 3 to "three-2"
         )
-        val pipeline = FlowStoreBuilder.fromNonFlow<Int, String, String>(fetcher::fetch)
+        val pipeline = FlowStoreBuilder.fromNonFlow(fetcher::fetch)
                 .scope(testScope)
                 .let {
                     if (enableCache) {


### PR DESCRIPTION
this version allows fluent builder w/o type parameters:

now you can literally write this:

```
FlowStoreBuilder
                .fromNonFlow(api::listFiles)
                .nonFlowingPersister(
                        reader = dao::read,
                        writer = dao::write).build()
```

If this sounds good, i think it is better to ditch FlowStoreBuilder and merge it into the StoreBuilder interface.
wdyt?